### PR TITLE
docs: fix typo in README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Facbook Messenger App
+# Facebook Messenger App
 
 Pack https://www.messenger.com/ as an App with electron.
 


### PR DESCRIPTION
## Summary
Fixed a typo in the README title ("Facbook" -> "Facebook").